### PR TITLE
Change async storage from react-native to react-native-community version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,20 @@ Keep your session sync with AsyncStorage and Redux :key:
 Redux React Native Session provides an simple API that allows to manage sessions through the app.
 
 ## Installation
+
+* Install:
+
 yarn:
 
 `yarn add redux-react-native-session`
 
 npm:
 
-`npm install redux-react-native-session --save`
+`npm install redux-react-native-session`
+
+* Link:
+
+`react-native link @react-native-community/async-storage`
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "webpack": "2.2.1"
   },
   "dependencies": {
+    "@react-native-community/async-storage": "^1.4.2",
     "immutable": "3.8.1"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { USER_SESSION, USER_DATA } from './constants';
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 import {
   getSessionSuccess,
   getSessionError,


### PR DESCRIPTION
React-native was warning that the react version of async-storage was deprecated in favor
of react-native-community version.
This can be tested adding this as a dependency on a project: `@peter7z/redux-react-native-session`
